### PR TITLE
:globe_with_meridians: Fix french dictionary not being translated

### DIFF
--- a/dictionaries/fr.dict.combodo-my-account.php
+++ b/dictionaries/fr.dict.combodo-my-account.php
@@ -7,6 +7,6 @@
  */
 
 Dict::Add('FR FR', 'French', 'Français', array(
-	'UI:MyAccount' => 'My Account',
-	'combodo-my-account/Operation:MainPage/Title' => 'My Account',
+	'UI:MyAccount' => 'Mon compte',
+	'combodo-my-account/Operation:MainPage/Title' => 'Mon compte',
 ));


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | No
| Type of change?                                               | Translations


## Symptom (bug)
Some entries of the new "My account" page in the backoffice are not translated in french:
![image](https://github.com/user-attachments/assets/a256bbee-844e-40fd-8991-d3598332bb04)


## Reproduction procedure (bug)
1. On iTop 3.2.1
2. With module version 1.0.0
3. With PHP 8.1.3
4. Log in the backoffice
5. Ensure user language is set to _french_
6. Go on the _My account_ page
7. See that most titles / sections are not translated


## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [X] Would a unit test be relevant and have I added it?
- [X] Is the PR clear and detailed enough so anyone can understand digging in the code?

## Checklist of things to do before PR is ready to merge
